### PR TITLE
Add function to allow end user set max listeners

### DIFF
--- a/lib/TestRunner.js
+++ b/lib/TestRunner.js
@@ -89,6 +89,16 @@ exports.setMaxRuntime = function (time) {
   maxRuntime = time;
 };
 
+/**
+ * Configure the max listeners on the EventEmitter
+ * By default, Node warns of potential memory leaks when 11 or more
+ * listeners are added. This allows the user to determine the safe limit
+ * @param {Number} n
+ */
+exports.setMaxListeners = function(n) {
+  eventEmitter.setMaxListeners(n);
+  log.i('Max Listeners set to ' + n);
+};
 
 /**
  * Executes all tests and provides results to the given callback.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-health",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A wrapper to add a health endpoint to your cloud application based on nodeapp.",
   "main": "./lib/TestRunner.js",
   "scripts": {


### PR DESCRIPTION
Added a small function to let the end user determine the max number of listeners that can be set on the EventEmitter.

Motivation
By default, Node starts to throw warnings after more than 10 listeners have been added (11 + tests). Currently in supercore, we have 11 tests added and it pollutes the logs every time the tests run with warnings we are not overly concerned about.

This change will allow the maximum to be adjusted to suit specific use cases
@evanshortiss Would you mind considering this change. Thanks